### PR TITLE
Get version string dynamically from POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@
 	</repositories>
 
 	<dependencies>
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-common</artifactId>
+		</dependency>
+
 		<!-- ImageJ dependencies -->
 		<dependency>
 			<groupId>net.imagej</groupId>

--- a/src/main/java/emblcmci/BleachCorrection.java
+++ b/src/main/java/emblcmci/BleachCorrection.java
@@ -41,6 +41,7 @@ import ij.gui.Roi;
 import ij.plugin.Duplicator;
 import ij.plugin.filter.PlugInFilter;
 import ij.process.ImageProcessor;
+import org.scijava.util.VersionUtils;
 
 public class BleachCorrection implements PlugInFilter {
 
@@ -131,7 +132,7 @@ public class BleachCorrection implements PlugInFilter {
 	public boolean showDialog() {
 		GenericDialog gd = new GenericDialog("Bleach Correction");
 		gd.addChoice("Correction Method :", CorrectionMethods, CorrectionMethods[CorrectionMethod]);
-		gd.addMessage("version 2.0.4");
+		gd.addMessage("version " + VersionUtils.getVersion(getClass()));
 		gd.addMessage("Citation doi: 10.12688/f1000research.27171.1");
 		gd.showDialog();
 		if (gd.wasCanceled())


### PR DESCRIPTION
This avoids that the version displayed in the dialog gets out of sync with the source code version.